### PR TITLE
Turn off the mic when switching providers

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -3,6 +3,7 @@
 // First version by Cohee#1207
 // Adapted by Tony-sama
 
+import { activateMicIcon, deactivateMicIcon } from './index.js';
 export { BrowserSttProvider };
 
 const DEBUG_PREFIX = '<Speech Recognition module (Browser)> ';
@@ -87,7 +88,7 @@ class BrowserSttProvider {
     onSettingsChange() {
         // Used when provider settings are updated from UI
         this.settings.language = $('#speech_recognition_browser_provider_language').val();
-        console.debug(DEBUG_PREFIX + 'Change language to',this.settings.language);
+        console.debug(DEBUG_PREFIX + 'Change language to', this.settings.language);
         this.loadSettings(this.settings);
     }
 
@@ -121,8 +122,8 @@ class BrowserSttProvider {
         // Initialise as defaultSettings
         this.settings = this.defaultSettings;
 
-        for (const key in settings){
-            if (key in this.settings){
+        for (const key in settings) {
+            if (key in this.settings) {
                 this.settings[key] = settings[key];
             } else {
                 throw `Invalid setting passed to Speech recogniton extension (browser): ${key}`;
@@ -211,16 +212,19 @@ class BrowserSttProvider {
 
         recognition.onend = function () {
             listening = false;
-            button.toggleClass('fa-microphone fa-microphone-slash');
+            console.debug(DEBUG_PREFIX + 'recorder stopped');
+            deactivateMicIcon(button);
+
             const newText = textarea.val().substring(initialText.length);
-            textarea.val(textarea.val().substring(0,initialText.length));
+            textarea.val(textarea.val().substring(0, initialText.length));
             processTranscript(newText);
 
         };
 
         recognition.onstart = function () {
             initialText = textarea.val();
-            button.toggleClass('fa-microphone fa-microphone-slash');
+            console.debug(DEBUG_PREFIX + 'recorder started');
+            activateMicIcon(button);
 
             if ($('#speech_recognition_message_mode').val() == 'replace') {
                 textarea.val('');

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ let audioRecording = false;
 const constraints = { audio: { sampleSize: 16, channelCount: 1, sampleRate: 16000 } };
 let audioChunks = [];
 
+/** @type {MediaRecorder} */
 let mediaRecorder = null;
 
 async function moduleWorker() {
@@ -370,19 +371,20 @@ function deactivateMicIcon(micButton) {
 
 function stopCurrentProvider() {
     console.debug(DEBUG_PREFIX + 'stop current provider');
-    if (mediaRecorder != null) {
+    if (mediaRecorder) {
         mediaRecorder.onstop = null;
         mediaRecorder.ondataavailable = null;
+        mediaRecorder.stream.getTracks().forEach(track => track.stop());
+        mediaRecorder.stop();
+        mediaRecorder = null;
     }
     if (audioRecording) {
         audioRecording = false;
-        mediaRecorder?.stop();
         const micButton = $('#microphone_button');
         if (micButton.is(':visible')) {
             deactivateMicIcon(micButton);
         }
     }
-    mediaRecorder = null;
 }
 
 function onSttLanguageChange() {


### PR DESCRIPTION
When switching the provider while the microphone is in recording mode, the microphone display and recording status became inverted. I have fixed this by stopping the recording of the previous provider when loading a new provider.

I understand that the current microphone icon implementation indicates possible actions, but personally, I feel it is more natural to display the current recording status (similar to the display method in many messaging apps like Zoom and Teams).
That said, ChatGPT (Android app) is close to the current SillyTavern implementation, so I think there may be some demand for it (although it differs in that the big stop button is displayed separately and prominently at the bottom).
Still, I made the title toggle "Click to talk" / "Click to stop talking" so that it might be a bit clearer.