### PR TITLE
Remove sampleRate for AudioContext due to FF not supporting this.

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,8 +207,8 @@ function loadNavigatorAudioRecording() {
         console.debug(DEBUG_PREFIX + ' getUserMedia supported by browser.');
         const micButton = $('#microphone_button');
 
-        let onSuccess = function (stream) {
-            const audioContext = new AudioContext({ sampleRate: 16000 });
+         let onSuccess = function (stream) {
+            const audioContext = new AudioContext();
             const source = audioContext.createMediaStreamSource(stream);
             const settings = {
                 source: source,

--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ function loadNavigatorAudioRecording() {
         console.debug(DEBUG_PREFIX + ' getUserMedia supported by browser.');
         const micButton = $('#microphone_button');
 
-         let onSuccess = function (stream) {
+        let onSuccess = function (stream) {
             const audioContext = new AudioContext();
             const source = audioContext.createMediaStreamSource(stream);
             const settings = {


### PR DESCRIPTION
I made test with kobolcpp (fresh Chrome and Firefox).

Before my fix:

- Chrome: always output "you" or "."
- Firefox: exception on `audioContext.createMediaStreamSource(stream)`

After my fix:

- Chrome: always output "you" or "."
- Firefox: work good

I couldn't explain these results :)
