### PR TITLE
Add OpenAI new transcription models

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import { saveSettingsDebounced, sendMessageAsUser } from '../../../../script.js'
 import { getContext, extension_settings, ModuleWorkerWrapper } from '../../../extensions.js';
 import { VoskSttProvider } from './vosk.js';
 import { WhisperExtrasSttProvider } from './whisper-extras.js';
-import { WhisperOpenAISttProvider } from './whisper-openai.js';
+import { OpenAISttProvider } from './whisper-openai.js';
 import { WhisperLocalSttProvider } from './whisper-local.js';
 import { BrowserSttProvider } from './browser.js';
 import { StreamingSttProvider } from './streaming.js';
@@ -27,7 +27,7 @@ let sttProviders = {
     Browser: BrowserSttProvider,
     'KoboldCpp': KoboldCppSttProvider,
     'Whisper (Extras)': WhisperExtrasSttProvider,
-    'Whisper (OpenAI)': WhisperOpenAISttProvider,
+    'OpenAI': OpenAISttProvider,
     'Whisper (Local)': WhisperLocalSttProvider,
     Vosk: VoskSttProvider,
     Streaming: StreamingSttProvider,
@@ -335,7 +335,7 @@ function loadSttProvider(provider) {
         $('#microphone_button').show();
     }
 
-    const nonStreamingProviders = ['Vosk', 'Whisper (OpenAI)', 'Whisper (Extras)', 'Whisper (Local)', 'KoboldCpp'];
+    const nonStreamingProviders = ['Vosk', 'OpenAI', 'Whisper (Extras)', 'Whisper (Local)', 'KoboldCpp'];
     if (nonStreamingProviders.includes(sttProviderName)) {
         sttProvider.loadSettings(extension_settings.speech_recognition[sttProviderName]);
         loadNavigatorAudioRecording();
@@ -435,6 +435,15 @@ function loadSettings() {
             extension_settings.speech_recognition[key] = defaultSettings[key];
         }
     }
+
+
+    if (extension_settings.speech_recognition.currentProvider === 'Whisper (OpenAI)') {
+        extension_settings.speech_recognition.currentProvider = 'OpenAI';
+    }
+    if (extension_settings.speech_recognition['Whisper (OpenAI)'] && !extension_settings.speech_recognition['OpenAI']) {
+        extension_settings.speech_recognition['OpenAI'] = extension_settings.speech_recognition['Whisper (OpenAI)'];
+    }
+
     $('#speech_recognition_enabled').prop('checked', extension_settings.speech_recognition.enabled);
     $('#speech_recognition_message_mode').val(extension_settings.speech_recognition.messageMode);
 

--- a/index.js
+++ b/index.js
@@ -436,7 +436,6 @@ function loadSettings() {
         }
     }
 
-
     if (extension_settings.speech_recognition.currentProvider === 'Whisper (OpenAI)') {
         extension_settings.speech_recognition.currentProvider = 'OpenAI';
     }

--- a/whisper-openai.js
+++ b/whisper-openai.js
@@ -1,33 +1,43 @@
 import { getRequestHeaders } from '../../../../script.js';
-export { WhisperOpenAISttProvider };
+export { OpenAISttProvider };
 
-const DEBUG_PREFIX = '<Speech Recognition module (Whisper OpenAI)> ';
+const DEBUG_PREFIX = '<Speech Recognition module (OpenAI)> ';
 
-class WhisperOpenAISttProvider {
+class OpenAISttProvider {
     settings;
 
     defaultSettings = {
         language: '',
+        model: 'whisper-1',
     };
 
     get settingsHtml() {
-        let html = '';
-        return html;
+        return `
+        <div class="flex-container flexFlowColumn" style="margin-top:8px">
+            <label for="openai_model">OpenAI Transcribe model</label>
+            <select id="openai_model">
+            <option value="gpt-4o-mini-transcribe">gpt-4o-mini-transcribe</option>
+            <option value="gpt-4o-transcribe">gpt-4o-transcribe</option>
+            <option value="whisper-1">whisper-1</option>
+            </select>
+        </div>
+        `;
     }
 
     onSettingsChange() {
         // Used when provider settings are updated from UI
+        const model = String($('#openai_model').val());
+        this.settings.model = model;
     }
 
     loadSettings(settings) {
         // Populate Provider UI given input settings
         if (Object.keys(settings).length == 0) {
-            console.debug(DEBUG_PREFIX + 'Using default Whisper (OpenAI) STT extension settings');
+            console.debug(DEBUG_PREFIX + 'Using default OpenAI STT extension settings');
         }
 
         // Only accept keys defined in defaultSettings
-        this.settings = this.defaultSettings;
-
+        this.settings = { ...this.defaultSettings };
         for (const key in settings) {
             if (key in this.settings) {
                 this.settings[key] = settings[key];
@@ -37,15 +47,15 @@ class WhisperOpenAISttProvider {
         }
 
         $('#speech_recognition_language').val(this.settings.language);
-        console.debug(DEBUG_PREFIX + 'Whisper (OpenAI) STT settings loaded');
+        $('#openai_model').val(this.settings.model);
+        console.debug(DEBUG_PREFIX + 'OpenAI STT settings loaded', this.settings);
     }
 
     async processAudio(audioBlob) {
         const requestData = new FormData();
         requestData.append('avatar', audioBlob, 'record.wav');
 
-        // TODO: Add model selection to settings when more models are available
-        requestData.append('model', 'whisper-1');
+        requestData.append('model', this.settings.model || this.defaultSettings.model);
 
         if (this.settings.language) {
             requestData.append('language', this.settings.language);
@@ -54,6 +64,7 @@ class WhisperOpenAISttProvider {
         // It's not a JSON, let fetch set the content type
         const headers = getRequestHeaders();
         delete headers['Content-Type'];
+        console.debug('Model STT: ', this.settings.model)
 
         const apiResult = await fetch('/api/openai/transcribe-audio', {
             method: 'POST',
@@ -62,7 +73,7 @@ class WhisperOpenAISttProvider {
         });
 
         if (!apiResult.ok) {
-            toastr.error(apiResult.statusText, 'STT Generation Failed (Whisper OpenAI)', { timeOut: 10000, extendedTimeOut: 20000, preventDuplicates: true });
+            toastr.error(apiResult.statusText, 'STT Generation Failed (OpenAI)', { timeOut: 10000, extendedTimeOut: 20000, preventDuplicates: true });
             throw new Error(`HTTP ${apiResult.status}: ${await apiResult.text()}`);
         }
 

--- a/whisper-openai.js
+++ b/whisper-openai.js
@@ -64,7 +64,7 @@ class OpenAISttProvider {
         // It's not a JSON, let fetch set the content type
         const headers = getRequestHeaders();
         delete headers['Content-Type'];
-        console.debug('Model STT: ', this.settings.model)
+        console.debug(DEBUG_PREFIX + 'Model STT: ', this.settings.model)
 
         const apiResult = await fetch('/api/openai/transcribe-audio', {
             method: 'POST',

--- a/whisper-openai.js
+++ b/whisper-openai.js
@@ -16,9 +16,9 @@ class OpenAISttProvider {
         <div class="flex-container flexFlowColumn" style="margin-top:8px">
             <label for="openai_model">OpenAI Transcribe model</label>
             <select id="openai_model">
-            <option value="gpt-4o-mini-transcribe">gpt-4o-mini-transcribe</option>
-            <option value="gpt-4o-transcribe">gpt-4o-transcribe</option>
-            <option value="whisper-1">whisper-1</option>
+                <option value="gpt-4o-mini-transcribe">gpt-4o-mini-transcribe</option>
+                <option value="gpt-4o-transcribe">gpt-4o-transcribe</option>
+                <option value="whisper-1">whisper-1</option>
             </select>
         </div>
         `;


### PR DESCRIPTION
## Description

Adds new better gpt-4o-transcribe and gpt-4o-mini-transcribe OpenAI models for STT.

## Main changes

### whisper_openai.js

- Adds select field to select model between whisper-1, gpt-4o-transcribe and gpt-4o-mini-transcribe
- Passes selected model to transcription endpoint

### index.js

- Change class names from Whisper (OpenAI) to OpenAI

## How to Test

- Open a chat/group
- Go to Speech recognition extension panel
- Select OpenAI as a STT provider
- Press the microphone button and record a message.
- Verify that the transcription is done with the proper model (from console logs or from openai api page directly)

## Note

- New models endpoints also support a prompt parameter, it is ignored for now